### PR TITLE
Apple M1 Support & Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Visual Studio Code
+[Bb]uild-vscode
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # main exe
-file(GLOB_RECURSE SRC_FILES "src/*.cpp" "src/*.h")
+file(GLOB_RECURSE SRC_FILES "src/*.cpp")
 add_executable(${PROJECT_NAME} ${SRC_FILES})
 
 # runtime data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,4 +14,6 @@ if (UNIX)
     target_link_libraries(${PROJECT_NAME} PRIVATE -lstdc++fs)
 endif()
 
+install(TARGETS ${PROJECT_NAME} DESTINATION "bin")
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/data/lists" DESTINATION "bin/data")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,6 @@ add_executable(${PROJECT_NAME} ${SRC_FILES})
 # runtime data
 file(COPY "${PROJECT_SOURCE_DIR}/data/lists/" DESTINATION "${CMAKE_BINARY_DIR}/data/lists/")
 
-# lstdc++fs shouldn't be needed when using the CXX 17 standard.
-#if (UNIX)
-#    target_link_libraries(${PROJECT_NAME} PRIVATE -lstdc++fs)
-#endif()
-
 install(TARGETS ${PROJECT_NAME} DESTINATION "bin")
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/data/lists" DESTINATION "bin/data")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,10 @@ add_executable(${PROJECT_NAME} ${SRC_FILES})
 # runtime data
 file(COPY "${PROJECT_SOURCE_DIR}/data/lists/" DESTINATION "${CMAKE_BINARY_DIR}/data/lists/")
 
-if (UNIX)
-    target_link_libraries(${PROJECT_NAME} PRIVATE -lstdc++fs)
-endif()
+# lstdc++fs shouldn't be needed when using the CXX 17 standard.
+#if (UNIX)
+#    target_link_libraries(${PROJECT_NAME} PRIVATE -lstdc++fs)
+#endif()
 
 install(TARGETS ${PROJECT_NAME} DESTINATION "bin")
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/data/lists" DESTINATION "bin/data")

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Exports go to `%USERPROFILE%/DMpowerExports/`.  Saves and settings go to `%USERP
 
 #### MAC
 
-Not tested, should be similar to linux.
+Exports go to `%HOME%/DMpowerExports/`.  Saves and settings go to `%HOME%/.dmpower`
 
 ## Sources
 

--- a/src/charts.cpp
+++ b/src/charts.cpp
@@ -74,10 +74,12 @@ void Charts::displayExperienceChart()
   pressEnterToContinue();
 }
 
+extern std::string RUNTIME_PATH;
+
 void Charts::displayPoisonSalesChart()
 {
   fstream poisonfile;
-  poisonfile.open(DATA_DIR + "poisonlist.dat");
+  poisonfile.open(RUNTIME_PATH + DATA_DIR + "poisonlist.dat");
   if (!poisonfile.is_open())
   {
    cout << "Error Opening poisonlist.dat, check your file.\n\n";
@@ -98,7 +100,7 @@ void Charts::displayPoisonSalesChart()
 void Charts::displayDiseaseChart()
 {
   fstream diseasefile;
-  diseasefile.open(DATA_DIR + "diseaselist.dat");
+  diseasefile.open(RUNTIME_PATH + DATA_DIR + "diseaselist.dat");
   if (!diseasefile.is_open())
   {
     cout << "Error Opening diseaselist.dat, check your file.\n\n";
@@ -122,7 +124,7 @@ void Charts::displayDiseaseChart()
 void Charts::displayMadnessChart()
 {
   fstream madnessfile;
-  madnessfile.open(DATA_DIR + "madnesslist.dat");
+  madnessfile.open(RUNTIME_PATH + DATA_DIR + "madnesslist.dat");
   if (!madnessfile.is_open())
   {
     cout << "Error Opening madnesslist.dat, check your file.\n\n";

--- a/src/charts.cpp
+++ b/src/charts.cpp
@@ -80,15 +80,15 @@ void Charts::displayPoisonSalesChart()
   poisonfile.open(DATA_DIR + "poisonlist.dat");
   if (!poisonfile.is_open())
   {
-    cout << "Error Opening poisonlist.dat, check your file.\n\n";
+   cout << "Error Opening poisonlist.dat, check your file.\n\n";
   }
   string poisons = "";
   if (poisonfile.is_open())
   {
-    while (!poisonfile.eof())
-    {
-      poisons += poisonfile.get();
-    }
+   while (!poisonfile.eof())
+   {
+     poisons += poisonfile.get();
+   }
   }
   poisons.erase(poisons.length() - 1, poisons.length()); //erase that last random [box] character
   cout << poisons;

--- a/src/charts.cpp
+++ b/src/charts.cpp
@@ -11,7 +11,8 @@ void Charts::showChartMenu()
   const int MAXCHARTCHOICE = 6;
   while (chart_choice != MAXCHARTCHOICE)
   {
-    if (clearScreens) simpleClearScreen();
+    if (clearScreens)
+      simpleClearScreen();
     cout
         << "----------------- CHARTS -----------------\n"
         << " 1. Player Behavioral Problems Flowchart\n"
@@ -82,18 +83,19 @@ void Charts::displayPoisonSalesChart()
   poisonfile.open(RUNTIME_PATH + DATA_DIR + "poisonlist.dat");
   if (!poisonfile.is_open())
   {
-   cout << "Error Opening poisonlist.dat, check your file.\n\n";
+    cout << "Error Opening poisonlist.dat, check your file.\n\n";
   }
   string poisons = "";
   if (poisonfile.is_open())
   {
-   while (!poisonfile.eof())
-   {
-     poisons += poisonfile.get();
-   }
+    while (!poisonfile.eof())
+    {
+      poisons += poisonfile.get();
+    }
   }
-  poisons.erase(poisons.length() - 1, poisons.length()); //erase that last random [box] character
+  poisons.erase(poisons.length() - 1, poisons.length()); // erase that last random [box] character
   cout << poisons;
+  poisonfile.close();
   pressEnterToContinue();
 }
 
@@ -115,9 +117,10 @@ void Charts::displayDiseaseChart()
         diseases += diseasefile.get();
       }
     }
-    diseases.erase(diseases.length() - 1, diseases.length()); //erase that last random [box] character
+    diseases.erase(diseases.length() - 1, diseases.length()); // erase that last random [box] character
     cout << diseases;
   }
+  diseasefile.close();
   pressEnterToContinue();
 }
 
@@ -137,14 +140,16 @@ void Charts::displayMadnessChart()
       madness += madnessfile.get();
     }
   }
-  madness.erase(madness.length() - 1, madness.length()); //erase that last random [box] character
+  madness.erase(madness.length() - 1, madness.length()); // erase that last random [box] character
   cout << madness;
+  madnessfile.close();
   pressEnterToContinue();
 }
 
 void Charts::walkThroughPlayerBehavioralResolutionChart()
 {
-  if (clearScreens) simpleClearScreen();
+  if (clearScreens)
+    simpleClearScreen();
   cout << "So a player is giving you trouble eh?\n"
        << "First, talk to them about it.\n";
 

--- a/src/gen_name.cpp
+++ b/src/gen_name.cpp
@@ -3,12 +3,14 @@
 #include <string>
 
 using namespace std;
+extern std::string RUNTIME_PATH;
 
 void CharacterName::grabRandomName(string &name)
 {
   ifstream fileOfNames;
   string tmpName;
-  fileOfNames.open(DATA_DIR + "names.dat");
+  const std::string full_name_file = RUNTIME_PATH + DATA_DIR + "names.dat";
+  fileOfNames.open(full_name_file);
 
   if (fileOfNames.is_open())
   {
@@ -29,7 +31,7 @@ void CharacterName::grabRandomName(string &name)
   }
   else
   {
-    tmpName = "error with name file, may be in use or if not, check code";
+    tmpName = "error with name file, may be in use or if not, check code | " + full_name_file;
   }
 
   if (*tmpName.rbegin() == '\r')

--- a/src/gen_reward.cpp
+++ b/src/gen_reward.cpp
@@ -5702,11 +5702,14 @@ void Magic_Items::SingleScroll(const int &lvl) const
     break;
   }
 }
+
+extern std::string RUNTIME_PATH;
+
 string Magic_Items::GenerateGemstone(const int &amount, const int &value) const
 {
   string gemstring = "error: check code or gemfile";
   ifstream fileOfGems;
-  fileOfGems.open(DATA_DIR + "gems.dat");
+  fileOfGems.open(RUNTIME_PATH + DATA_DIR + "gems.dat");
   if (fileOfGems.is_open())
   {
     string tmpName = "";
@@ -5850,7 +5853,7 @@ string Magic_Items::GenerateArt(const int &amount, const int &value) const
 {
   string artstring = "error: check code or artfile";
   ifstream fileOfArt;
-  fileOfArt.open(DATA_DIR + "artObjects.dat");
+  fileOfArt.open(RUNTIME_PATH + DATA_DIR + "artObjects.dat");
   if (fileOfArt.is_open())
   {
     string tmpName = "";

--- a/src/globalfuncts.cpp
+++ b/src/globalfuncts.cpp
@@ -6,7 +6,7 @@
 
 std::string lastSave;
 bool is_random = false; // for the random character gen operation triggers
-std::string buildNumber = "12"; // iterate with every new build release
+std::string buildNumber = "13"; // iterate with every new build release
 std::string saveVersion = "9"; // oldest version the current saves work with
 std::string mainMessage;
 bool loadSuccess = false;
@@ -142,7 +142,6 @@ int getNumber(const std::string& message, const int& a, const int& b) {
 
   if (is_random) {
     int rand_num = randomNumber(a, b);
-    std::cout << message << rand_num << '\n';
     return rand_num;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,12 @@
 #include "globalfuncts.h"
-
-int main()
+std::string RUNTIME_PATH;
+int main(int argc, char *argv[])
 {
+  {
+    const std::string executable_path(argv[0]);
+    auto last_slash_pos = executable_path.find_last_of("/\\");
+    RUNTIME_PATH = executable_path.substr(0, last_slash_pos + 1);
+  }
 
   set_user_pref_from_file();
 

--- a/src/save.cpp
+++ b/src/save.cpp
@@ -11,8 +11,9 @@
 #include <windows.h>
 #include <shlobj.h>
 #include <objbase.h>
-std::filesystem::path get_user_profile_path() {
-  wchar_t* p;
+std::filesystem::path get_user_profile_path()
+{
+  wchar_t *p;
   if (S_OK != SHGetKnownFolderPath(FOLDERID_Profile, 0, NULL, &p))
     return "";
   std::filesystem::path result = p;
@@ -24,31 +25,37 @@ const std::string os_app_data = "/AppData/Local/dmpower";
 const std::string user_document_area = "/Documents/DMpowerExports";
 const std::string ROOT_SAVE_DIR = user_profile_path.string();
 #include <fileapi.h>
-bool create_dir(const char* path) {
+bool create_dir(const char *path)
+{
   // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createdirectorya
   // If the function succeeds, the return value is true.
   bool wasSuccessful = CreateDirectoryA(path, NULL);
-  if (!wasSuccessful) {
+  if (!wasSuccessful)
+  {
     DWORD last_error = GetLastError();
-    if (last_error == ERROR_ALREADY_EXISTS) {
+    if (last_error == ERROR_ALREADY_EXISTS)
+    {
       // perfectly fine option
       wasSuccessful = true;
-    } else if (last_error == ERROR_PATH_NOT_FOUND) {
+    }
+    else if (last_error == ERROR_PATH_NOT_FOUND)
+    {
       std::cout << "!!!!!!!!DEBUG!!!!!!!!!!!!!\n";
       std::cout << "path: " << path << " NOT FOUND (not final part only?)\n";
     }
   }
   return wasSuccessful;
 }
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <cstdlib>
 #include <errno.h>
 #include <cstring>
-std::filesystem::path get_user_profile_path() {
+std::filesystem::path get_user_profile_path()
+{
   std::cout << "getting linux user profile...\n\n\n";
-  const char* p = getenv("HOME");
+  const char *p = getenv("HOME");
   std::filesystem::path result = p;
   return result;
 }
@@ -56,47 +63,55 @@ const std::filesystem::path user_profile_path = get_user_profile_path();
 const std::string os_app_data = "/.dmpower";
 const std::string user_document_area = "/DMpowerExports";
 const std::string ROOT_SAVE_DIR = user_profile_path.string();
-bool create_dir(const char* path) {
+bool create_dir(const char *path)
+{
   std::string create_path = "mkdir -p ";
   create_path.append(path);
-  //Upon successful completion, mkdir() shall return 0.
-  // Otherwise, -1 shall be returned, no directory shall be created, and errno shall be set to indicate the error.
+  // Upon successful completion, mkdir() shall return 0.
+  //  Otherwise, -1 shall be returned, no directory shall be created, and errno shall be set to indicate the error.
   bool wasSuccessful = system(create_path.c_str()); // call system to make the folder structure to path
   wasSuccessful = !wasSuccessful;                   // flip to make it correct
-  if (!wasSuccessful) {
+  if (!wasSuccessful)
+  {
     std::cout << "Error : " << std::strerror(errno) << std::endl;
-    if (errno == EEXIST) {
+    if (errno == EEXIST)
+    {
       std::cout << "but dir does exist\n";
       wasSuccessful = true; // fine
     }
-  } else {
+  }
+  else
+  {
     std::cout << "Directories are created" << std::endl;
   }
   return wasSuccessful;
 }
 #endif
 
-
 const std::string DOCUMENT_SAVE_DIR = ROOT_SAVE_DIR + user_document_area;
 const std::string APP_DATA_DIR = ROOT_SAVE_DIR + os_app_data;
 const std::string CAMPAIGN_SAVE_DIR = ROOT_SAVE_DIR + os_app_data + "/saves";
 const std::string SETTINGS_SAVE_DIR = ROOT_SAVE_DIR + os_app_data + "/settings";
 
-
-void truncateSaveForThisVersion(std::string& original, std::string& edited) {
+void truncateSaveForThisVersion(std::string &original, std::string &edited)
+{
   edited.clear();
   std::size_t pos1 = original.find_last_of("/\\");
   std::size_t pos2 = original.find(".dmpsave");
 
   edited = original.substr(pos1 + 1, pos2 - pos1 - 1);
 }
-void showLoadableFiles(const std::string& dir) {
+void showLoadableFiles(const std::string &dir)
+{
   const std::filesystem::path dir_path(dir);
 
-  if (!exists(dir_path)) {
+  if (!exists(dir_path))
+  {
     std::cout << "showLoadableFiles: path to directory (" << dir << ") does not exist\n";
     return;
-  } else {
+  }
+  else
+  {
     std::cout << "List of loadable saves:\n";
   }
 
@@ -105,14 +120,16 @@ void showLoadableFiles(const std::string& dir) {
   std::string edited_ver;
   int number_of_loadable_saves = 0;
 
-  for (std::filesystem::directory_iterator itr(dir_path); itr != end_itr; ++itr) {
+  for (std::filesystem::directory_iterator itr(dir_path); itr != end_itr; ++itr)
+  {
     std::stringstream ss;
     ss << itr->path();
     std::string original_ver;
     ss >> original_ver;
 
-    //ignore anything that is not *.dmpsave
-    if (original_ver.find(".dmpsave") == std::string::npos) {
+    // ignore anything that is not *.dmpsave
+    if (original_ver.find(".dmpsave") == std::string::npos)
+    {
       continue;
     }
 
@@ -123,38 +140,41 @@ void showLoadableFiles(const std::string& dir) {
   }
   std::cout << '\n';
 
-  if (number_of_loadable_saves > 0) {
+  if (number_of_loadable_saves > 0)
+  {
     std::cout << YELLOW << "additional save management commands:" << RESET << '\n';
     std::cout << "   combine 2 files: '" << GREEN << "combine SaveToKeep SaveToMergeIn" << RESET << "'\n";
     std::cout << "   delete a file: '" << GREEN << "delete SaveToDelete" << RESET << "'\n";
     std::cout << '\n';
   }
 }
-bool mergeSaves(const std::string& keep, const std::string& mergein) {
+bool mergeSaves(const std::string &keep, const std::string &mergein)
+{
   std::cout << "mergeSaves function disabled\n";
-  //std::ofstream saveto;
-  //saveto.open((CAMPAIGN_SAVE_DIR + "/" + keep + ".dmpsave").c_str(), std::ios_base::app); //open write-to file with append
+  // std::ofstream saveto;
+  // saveto.open((CAMPAIGN_SAVE_DIR + "/" + keep + ".dmpsave").c_str(), std::ios_base::app); //open write-to file with append
 
-  //std::ifstream readfrom;
-  //readfrom.open((CAMPAIGN_SAVE_DIR + "/" + mergein + ".dmpsave").c_str());
+  // std::ifstream readfrom;
+  // readfrom.open((CAMPAIGN_SAVE_DIR + "/" + mergein + ".dmpsave").c_str());
 
-  //if (saveto.is_open() && readfrom.is_open()) {
-  //  std::string tmp;
-  //  getline(readfrom, tmp); // eat the first line which is the save version
-  //  do {
-  //    std::getline(readfrom, tmp);
-  //    if (readfrom.eof())
-  //      break;
-  //    saveto << tmp << '\n';
-  //  } while (!readfrom.eof());
-  //  return true;
-  //} else {
-  //  std::cout << "Error opening both requested files\n";
-  //}
-  //return false;
+  // if (saveto.is_open() && readfrom.is_open()) {
+  //   std::string tmp;
+  //   getline(readfrom, tmp); // eat the first line which is the save version
+  //   do {
+  //     std::getline(readfrom, tmp);
+  //     if (readfrom.eof())
+  //       break;
+  //     saveto << tmp << '\n';
+  //   } while (!readfrom.eof());
+  //   return true;
+  // } else {
+  //   std::cout << "Error opening both requested files\n";
+  // }
+  // return false;
   return true;
 }
-void createUserFolders() {
+void createUserFolders()
+{
   // create these directories to make sure they exist
   if (create_dir(ROOT_SAVE_DIR.c_str()))
     std::cout << ROOT_SAVE_DIR << " now exists" << std::endl;
@@ -171,29 +191,38 @@ void createUserFolders() {
   if (create_dir(DOCUMENT_SAVE_DIR.c_str()))
     std::cout << DOCUMENT_SAVE_DIR << " now exists" << std::endl;
 }
-void note_last_save(const std::string& save_name) {
+void note_last_save(const std::string &save_name)
+{
   /** Routine to take note of the last save so that load_last_save() func can use it. */
   lastSave = save_name;
   std::ofstream os((SETTINGS_SAVE_DIR + "/lastSave.dat").c_str());
-  if (os.is_open()) {
+  if (os.is_open())
+  {
     os << lastSave;
-  } else {
+  }
+  else
+  {
     lastSave.clear();
   }
 }
-void load_file(const std::string& filename) {
-  if (filename.length() > 0) {
+void load_file(const std::string &filename)
+{
+  if (filename.length() > 0)
+  {
     std::ifstream thefile;
     thefile.open((CAMPAIGN_SAVE_DIR + "/" + filename + ".dmpsave").c_str());
-    if (thefile.fail()) {
+    if (thefile.fail())
+    {
       std::cout << "Could not open file (fail triggered)\n";
       return;
     }
-    if (thefile.is_open()) {
+    if (thefile.is_open())
+    {
       int return_code = myGame.retrieveCharacter(thefile);
 
       // notify user of the result of the load
-      switch (return_code) {
+      switch (return_code)
+      {
       case 1:
         mainMessage = "File '" + filename + "' loaded.";
         loadedFile = filename;
@@ -218,43 +247,51 @@ void load_file(const std::string& filename) {
 
 // called from outside
 
-void load_last_save() {
+void load_last_save()
+{
   /** Routine to check what the user last saved and load it. Variable last_save is cleared if this fails. */
   lastSave.clear();
   std::ifstream fs(SETTINGS_SAVE_DIR + "/lastSave.dat");
-  if (fs.is_open()) {
+  if (fs.is_open())
+  {
     std::string holder;
     std::getline(fs, holder); // should be the first line
-    if (!holder.empty()) {
+    if (!holder.empty())
+    {
       lastSave = holder;
     }
     load_file(lastSave);
   }
 }
-void load_file() {
+void load_file()
+{
   if (clearScreens)
     simpleClearScreen();
-  //show list of previous saves
-  showLoadableFiles(CAMPAIGN_SAVE_DIR); //check
+  // show list of previous saves
+  showLoadableFiles(CAMPAIGN_SAVE_DIR); // check
 
   std::string file;
   std::cout << "(leave blank to skip) Load File: ";
   std::getline(std::cin, file, '\n');
   reduce(file);
 
-  //combine saves option
-  // if the word is combine followed by a space,
-  // the next 2 words should be the one to keep and the one to merge in
-  if (file.substr(0, 8) == "combine ") {
+  // combine saves option
+  //  if the word is combine followed by a space,
+  //  the next 2 words should be the one to keep and the one to merge in
+  if (file.substr(0, 8) == "combine ")
+  {
     std::string keep, mergein;
-    if (file.find_first_of(" ", 8) != std::string::npos) {
+    if (file.find_first_of(" ", 8) != std::string::npos)
+    {
       size_t pos1 = file.find_first_of(" ", 8);
       keep = file.substr(8, pos1 - 8);
       mergein = file.substr(pos1 + 1);
       bool mergesuccess = mergeSaves(keep, mergein);
-      if (mergesuccess) {
+      if (mergesuccess)
+      {
         std::string removestuff = "rm user/saves/" + mergein + ".dmpsave";
-        if (system(removestuff.c_str())) {
+        if (system(removestuff.c_str()))
+        {
           std::cout << "unable to remove file '" << mergein << "'\n";
         }
         load_file();
@@ -264,7 +301,8 @@ void load_file() {
 
   // delete saves option
   // if the word is delete followed by a space, the next word should be the file to delete
-  else if (file.substr(0, 7) == "delete ") {
+  else if (file.substr(0, 7) == "delete ")
+  {
     std::cout << "function removed\n";
     /*std::string fileToRemove;
     if (file.find_first_not_of(" ", 7) != std::string::npos) {
@@ -276,18 +314,23 @@ void load_file() {
       }
       load_file();
     }*/
-  } else if (file.length() > 0) {
+  }
+  else if (file.length() > 0)
+  {
     std::ifstream thefile;
     thefile.open((CAMPAIGN_SAVE_DIR + "/" + file + ".dmpsave").c_str());
-    if (thefile.fail()) {
+    if (thefile.fail())
+    {
       std::cout << "Could not open file (fail triggered)\n";
       return;
     }
-    if (thefile.is_open()) {
+    if (thefile.is_open())
+    {
       int return_code = myGame.retrieveCharacter(thefile);
 
       // notify user of the result of the load
-      switch (return_code) {
+      switch (return_code)
+      {
       case 1:
         mainMessage = "File '" + file + "' loaded.";
         loadedFile = file;
@@ -309,24 +352,30 @@ void load_file() {
     }
   }
 }
-void auto_save() {
-  if (loadedFile.empty()) {
+void auto_save()
+{
+  if (loadedFile.empty())
+  {
     return; // no file to save too, can't auto-save, load something or save something first
   }
 
   createUserFolders();
 
   std::ofstream os;
-  //save into file
+  // save into file
   os.open((CAMPAIGN_SAVE_DIR + "/" + loadedFile + ".dmpsave").c_str());
-  if (os.is_open()) {
+  if (os.is_open())
+  {
     myGame.dumpCharacter(os);
 
-    if (mainMessage.size() < 1) {
+    if (mainMessage.size() < 1)
+    {
       mainMessage.clear();
       mainMessage = "Auto Saved to: ";
       mainMessage += loadedFile;
-    } else {
+    }
+    else
+    {
       mainMessage += ". Auto Saved to: ";
       mainMessage += loadedFile;
     }
@@ -336,8 +385,10 @@ void auto_save() {
     os.close();
   }
 }
-void save_file() {
-  if (myGame.character_list.empty()) {
+void save_file()
+{
+  if (myGame.character_list.empty())
+  {
     mainMessage = "Nothing to save - character list empty";
     return;
   }
@@ -347,12 +398,15 @@ void save_file() {
   // get file save as (with check and reduce) from user
   std::string file;
   std::ofstream os;
-  if (loadSuccess == false) {
+  if (loadSuccess == false)
+  {
     std::cout << "Save As: ";
     bool done_first_pass = false;
     bool contains_non_alpha = true;
-    do {
-      if (done_first_pass) {
+    do
+    {
+      if (done_first_pass)
+      {
         std::cout << file << " is an invalid name. Use only characters a-z & A-Z & 0-9\n";
         std::cout << "Save As: ";
       }
@@ -361,12 +415,15 @@ void save_file() {
       contains_non_alpha = file.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") != std::string::npos;
       done_first_pass = true;
     } while (contains_non_alpha);
-  } else {
+  }
+  else
+  {
     file = loadedFile;
   }
-  //save into save path after above is complete
+  // save into save path after above is complete
   os.open((CAMPAIGN_SAVE_DIR + "/" + file + ".dmpsave").c_str());
-  if (os.is_open()) {
+  if (os.is_open())
+  {
     myGame.dumpCharacter(os);
     mainMessage = "All data saved in file: " + file;
     loadSuccess = true;

--- a/src/terminal_colors.h
+++ b/src/terminal_colors.h
@@ -30,4 +30,12 @@ const std::string YELLOW = "";
 const std::string BLUE = "";
 const std::string MAGENTA = "";
 const std::string CYAN = "";
+#elif __APPLE__
+const std::string RESET = "\e[0m";
+const std::string RED = "\e[31m";
+const std::string GREEN = "\e[32m";
+const std::string YELLOW = "\e[33m";
+const std::string BLUE = "\e[34m";
+const std::string MAGENTA = "\e[35m";
+const std::string CYAN = "\e[36m";
 #endif


### PR DESCRIPTION
Closed all files within charts as they were not needed. I believe the only way they go out of scope and close is if you do something a bit hackish with pointers to the file and then let them drop out when no longer in scope. Just updated to close them for clarity.

Removed the -lstdc++fs, which was used previously with GCC and is no longer required since the C++ 17 standard includes it by default. 

Testing under Apple/Debian reveals the poison chart loads correctly. Also tested running the file operations for character loading/saving, and they generated as expected.

<img width="493" alt="Screen Shot 2022-07-18 at 12 05 07 AM" src="https://user-images.githubusercontent.com/64661963/179445034-2bb2df64-da8b-49e7-82d6-f215795e8e0e.png">


Updated the console definition for colors to support Apple.

My linter decided to change styles on files touched, so you may have to re-lint them to your liking.